### PR TITLE
done hw05

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,12 +1,14 @@
 // 小彭老师作业05：假装是多线程 HTTP 服务器 - 富连网大厂面试官觉得很赞
+#include <chrono>
+#include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <map>
+#include <shared_mutex>
 #include <sstream>
-#include <cstdlib>
 #include <string>
 #include <thread>
-#include <map>
-
+#include <vector>
 
 struct User {
     std::string password;
@@ -15,11 +17,14 @@ struct User {
 };
 
 std::map<std::string, User> users;
-std::map<std::string, long> has_login;  // 换成 std::chrono::seconds 之类的
+std::map<std::string, std::chrono::steady_clock::time_point> has_login;  // 换成 std::chrono::seconds 之类的
+std::shared_mutex users_mtx;
+std::shared_mutex has_login_mtx;
 
 // 作业要求1：把这些函数变成多线程安全的
 // 提示：能正确利用 shared_mutex 加分，用 lock_guard 系列加分
 std::string do_register(std::string username, std::string password, std::string school, std::string phone) {
+    std::unique_lock grd(users_mtx);  // 需求为写，使用 std::unique_lock
     User user = {password, school, phone};
     if (users.emplace(username, user).second)
         return "注册成功";
@@ -29,21 +34,34 @@ std::string do_register(std::string username, std::string password, std::string 
 
 std::string do_login(std::string username, std::string password) {
     // 作业要求2：把这个登录计时器改成基于 chrono 的
-    long now = time(NULL);   // C 语言当前时间
-    if (has_login.find(username) != has_login.end()) {
-        int sec = now - has_login.at(username);  // C 语言算时间差
-        return std::to_string(sec) + "秒内登录过";
+    auto now = std::chrono::steady_clock::now();
+    {
+        std::shared_lock grd(has_login_mtx);  // 需求为读，使用 std::shared_lock
+        if (has_login.find(username) != has_login.end()) {
+            auto dt = now - has_login.at(username);
+            using double_sec = std::chrono::duration<double>;
+            double sec = std::chrono::duration_cast<double_sec>(dt).count();
+            return std::to_string(sec) + "秒内登录过";
+        }
     }
-    has_login[username] = now;
-
-    if (users.find(username) == users.end())
-        return "用户名错误";
-    if (users.at(username).password != password)
-        return "密码错误";
-    return "登录成功";
+    {
+        std::unique_lock grd(has_login_mtx);  // 需求为写，使用 std::unique_lock
+        has_login[username] = now;
+    }
+    {
+        std::shared_lock grd(users_mtx);  // 需求为读，使用 std::shared_lock
+        if (users.find(username) == users.end())
+            return "用户名错误";
+        if (users.at(username).password != password)
+            return "密码错误";
+        return "登录成功";
+    }
 }
 
 std::string do_queryuser(std::string username) {
+    std::shared_lock grd(users_mtx);  // 需求为读，使用 std::shared_lock
+    if (users.find(username) == users.end())
+        return "用户名错误";
     auto &user = users.at(username);
     std::stringstream ss;
     ss << "用户名: " << username << std::endl;
@@ -52,24 +70,29 @@ std::string do_queryuser(std::string username) {
     return ss.str();
 }
 
-
 struct ThreadPool {
+    std::vector<std::thread> pool;
+
+public:
     void create(std::function<void()> start) {
         // 作业要求3：如何让这个线程保持在后台执行不要退出？
         // 提示：改成 async 和 future 且用法正确也可以加分
         std::thread thr(start);
+        pool.push_back(std::move(thr));
+    }
+    ~ThreadPool() {
+        for (auto &t : pool) t.join();
     }
 };
 
 ThreadPool tpool;
-
 
 namespace test {  // 测试用例？出水用力！
 std::string username[] = {"张心欣", "王鑫磊", "彭于斌", "胡原名"};
 std::string password[] = {"hellojob", "anti-job42", "cihou233", "reCihou_!"};
 std::string school[] = {"九百八十五大鞋", "浙江大鞋", "剑桥大鞋", "麻绳理工鞋院"};
 std::string phone[] = {"110", "119", "120", "12315"};
-}
+}  // namespace test
 
 int main() {
     for (int i = 0; i < 262144; i++) {


### PR DESCRIPTION
1. 把 login, register 等函数变成多线程安全的 - 10 分
    - 为两个对象使用了两个 `std::shared_mutex`。
2. 把 login 的登录计时器改成基于 chrono 的 - 5 分
    - 改了。
3. 能利用 shared_mutex 区分读和写 - 10 分
    - 见 1。
4. 用 lock_guard 系列符合 RAII 思想 - 5 分
    - 读写的情景下分别使用 `std::shared_lock` 和 `std::unique_lock` 加锁。
5. 让 ThreadPool::create 创建的线程保持后台运行不要退出 - 15 分
    - 修改了线程池，移交生命周期给 `std::vector`。
6. 等待 tpool 中所有线程都结束后再退出 - 5 分
    - 在线程池析构函数中调用`.join()`。