### PR TITLE
finish hw05

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(hellocmake LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()


### PR DESCRIPTION
使用两个锁分别管理users和login容器的读写，读操作用shared_lock ,写用unique_lock。

创建线程vector，延长内部线程的生命周期，使用jthread方法可以在销毁前自动调用join方法，使线程继续执行到进程结束。

查询用户时如果用户不存在需要返回一个失败值，如果使用wait和notify会导致莫名死锁而程序无法退出，因而使用try catch。

测试线程过大因而无法合理处置爆掉的情况。