### PR TITLE
Riga finished hw5!

### DIFF
--- a/MTQueue.h
+++ b/MTQueue.h
@@ -43,7 +43,7 @@ public:
     }
 };
 
-int main() {
+/*int main() {
     MTQueue<int> foods;
 
     std::thread t1([&] {
@@ -68,4 +68,4 @@ int main() {
     t2.join();
 
     return 0;
-}
+}*/


### PR DESCRIPTION
### 完成了基本要求！

1. 把 login, register 等函数变成多线程安全的 - 10 分
    * 使用了两个shared_mutex，同时配合unique_lock和shared_lock完成了该功能
2. 把 login 的登录计时器改成基于 chrono 的 - 5 分
    * 直接改
3. 能利用 shared_mutex 区分读和写 - 10 分
    * 写的时候加unique_lock，读的时候加shared_lock
4. 用 lock_guard 系列符合 RAII 思想 - 5 分
    * unique_lock和shared_lock 符合 RAII
5. 让 ThreadPool::create 创建的线程保持后台运行不要退出 - 15 分
    * 20万个线程直接运行直接崩....
    * 查了资料发现要用任务队列，正好提供了一个MTQueue，然后十分粗糙的改写了一下
    * 此处发现最后面是个死循环，最后加了个atomic变量存执行的任务数，加了个判断让任务执行完时线程才退出。
6. 等待 tpool 中所有线程都结束后再退出 - 5 分
    * vector存线程，析构的时候join