### PR TITLE
hw05 completed

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,11 @@
 #include <string>
 #include <thread>
 #include <map>
+#include <utility>
+#include <shared_mutex>
+#include <chrono>
+#include <mutex>
+#include <future>
 
 
 struct User {
@@ -15,12 +20,16 @@ struct User {
 };
 
 std::map<std::string, User> users;
-std::map<std::string, long> has_login;  // 换成 std::chrono::seconds 之类的
+std::map<std::string, std::chrono::steady_clock::time_point> has_login;  // 换成 std::chrono::seconds 之类的
+std::shared_mutex sm;
+std::shared_mutex sm_login;
 
 // 作业要求1：把这些函数变成多线程安全的
 // 提示：能正确利用 shared_mutex 加分，用 lock_guard 系列加分
 std::string do_register(std::string username, std::string password, std::string school, std::string phone) {
-    User user = {password, school, phone};
+    User user = {std::move(password), std::move(school), std::move(phone)};
+
+    std::unique_lock grd(sm);
     if (users.emplace(username, user).second)
         return "注册成功";
     else
@@ -29,13 +38,29 @@ std::string do_register(std::string username, std::string password, std::string 
 
 std::string do_login(std::string username, std::string password) {
     // 作业要求2：把这个登录计时器改成基于 chrono 的
-    long now = time(NULL);   // C 语言当前时间
-    if (has_login.find(username) != has_login.end()) {
-        int sec = now - has_login.at(username);  // C 语言算时间差
-        return std::to_string(sec) + "秒内登录过";
-    }
-    has_login[username] = now;
+//    long now = time(NULL);   // C 语言当前时间
+//    if (has_login.find(username) != has_login.end()) {
+//        int sec = now - has_login.at(username);  // C 语言算时间差
+//        return std::to_string(sec) + "秒内登录过";
+//    }
+//    has_login[username] = now;
 
+    std::shared_lock grd_log_sl(sm_login);
+    auto find=has_login.find(username) != has_login.end();
+    grd_log_sl.unlock();
+
+    auto now=std::chrono::steady_clock::now();
+    if (find) {
+        auto sec=now-has_login.at(username);
+        using double_s=std::chrono::duration<double>;
+        double s=std::chrono::duration_cast<double_s>(sec).count();
+        return std::to_string(s) + "秒内登录过";
+    }
+    std::unique_lock grd_log(sm_login);
+    has_login[username] = now;
+    grd_log.unlock();
+
+    std::shared_lock grd(sm);
     if (users.find(username) == users.end())
         return "用户名错误";
     if (users.at(username).password != password)
@@ -44,7 +69,9 @@ std::string do_login(std::string username, std::string password) {
 }
 
 std::string do_queryuser(std::string username) {
+    std::shared_lock grd(sm);
     auto &user = users.at(username);
+    grd.unlock();
     std::stringstream ss;
     ss << "用户名: " << username << std::endl;
     ss << "学校:" << user.school << std::endl;
@@ -57,8 +84,10 @@ struct ThreadPool {
     void create(std::function<void()> start) {
         // 作业要求3：如何让这个线程保持在后台执行不要退出？
         // 提示：改成 async 和 future 且用法正确也可以加分
-        std::thread thr(start);
+//        std::thread thr(start);
+        fts.push_back(std::async(start));
     }
+    std::vector<std::future<void>> fts;
 };
 
 ThreadPool tpool;
@@ -85,5 +114,8 @@ int main() {
     }
 
     // 作业要求4：等待 tpool 中所有线程都结束后再退出
+    for (auto &ret:tpool.fts) {
+            ret.get();
+    }
     return 0;
 }


### PR DESCRIPTION
- 把 `login`, `register` 等函数变成多线程安全的 - 10 分
- 把 `login` 的登录计时器改成基于 chrono 的 - 5 分
- 能利用 `shared_mutex` 区分读和写 - 10 分
- 用 `lock_guard` 系列符合 RAII 思想 - 5 分
- 让 ThreadPool::create 创建的线程保持后台运行不要退出 - 15 分
- 等待 tpool 中所有线程都结束后再退出 - 5 分

并通过 `main()` 函数中的基本测试。

1. 对全局变量`users`以及`has_login`，分别用`shared_mutex`进行互斥保护。用`shared_mutex`是为了实现读写锁。并且为了提高性能，尽量最小化互斥区代码，在适当的时候`unlock`释放锁
2. 使用`std::chrono::steady_clock::now()`获取时间，并用`std::chrono::duration`转换为秒数
3. 读写锁`shared_mutex`，见第一点
4. 用`unique_lock`以及`shared_lock`实现读写锁，其实用`lock_guard`性能会更高
5. 在`ThreadPool`中定义`std::vector<std::future<void>>`数据成员，每次`create`调用时，调用`async`将返回值`push`到`vector`中。
6. 在main函数返回前，对线程池的每个`future`对象调用`wait`。
7. 另外，在`do_queryuser`中，不能直接`users.at(username)`，否则可能会报out_of_range异常。
